### PR TITLE
카드 내 설명을 최대, 최대 3줄로 고정하여 보여준다.

### DIFF
--- a/web/src/components/common/CardDescription.tsx
+++ b/web/src/components/common/CardDescription.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface CardDescriptionProps {
+  children: React.ReactNode;
+}
+
+const CardDescription = ({ children }: CardDescriptionProps) => {
+  return <p className="text-default-500 line-clamp-3 text-sm h-[3.75rem]">{children}</p>;
+};
+
+export default CardDescription;

--- a/web/src/components/dashboard/DraftExamCard.tsx
+++ b/web/src/components/dashboard/DraftExamCard.tsx
@@ -11,6 +11,7 @@ import {
   Image,
   Link,
 } from '@nextui-org/react';
+import CardDescription from '../common/CardDescription';
 
 interface ExamSummaryCardProps {
   exam: ExamSummaryResponse;
@@ -35,7 +36,7 @@ const DraftExamCard = ({ exam }: ExamSummaryCardProps) => {
       <Divider />
       <CardBody>
         <h3 className="text-lg font-semibold">{exam.title}</h3>
-        <p className="text-default-500 line-clamp-3">{exam.description}</p>
+        <CardDescription>{exam.description}</CardDescription>
       </CardBody>
       <Divider />
       <CardFooter className="flex justify-between">

--- a/web/src/components/dashboard/SubmittedExamCard.tsx
+++ b/web/src/components/dashboard/SubmittedExamCard.tsx
@@ -2,6 +2,7 @@ import { SubmittedExamSummaryResponse } from '@/api/examAPI';
 import { Routes } from '@/constants';
 import { fromNowDate } from '@/lib/date.ts';
 import { Card, CardBody, CardFooter, CardHeader, Divider, Image, Link } from '@nextui-org/react';
+import CardDescription from '../common/CardDescription';
 
 interface SubmittedExamCardProps {
   submittedExam: SubmittedExamSummaryResponse;
@@ -28,7 +29,7 @@ const SubmittedExamCard = ({ submittedExam }: SubmittedExamCardProps) => {
       <Divider />
       <CardBody>
         <h3 className="text-lg font-semibold">{submittedExam.title}</h3>
-        <p className="text-default-500 line-clamp-3">{submittedExam.description}</p>
+        <CardDescription>{submittedExam.description}</CardDescription>
       </CardBody>
       <Divider />
       <CardFooter className="flex justify-between">

--- a/web/src/components/exams/ExamSummaryCard.tsx
+++ b/web/src/components/exams/ExamSummaryCard.tsx
@@ -14,6 +14,7 @@ import {
 } from '@nextui-org/react';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router';
+import CardDescription from '../common/CardDescription';
 
 interface ExamSummaryCardProps {
   exam: ExamSummaryResponse;
@@ -54,7 +55,7 @@ const ExamSummaryCard = ({ exam }: ExamSummaryCardProps) => {
       <Divider />
       <CardBody>
         <h3 className="text-lg font-semibold">{exam.title}</h3>
-        <p className="text-default-500 line-clamp-3">{exam.description}</p>
+        <CardDescription>{exam.description}</CardDescription>
       </CardBody>
       <Divider />
       <CardFooter className="flex justify-between">


### PR DESCRIPTION
## 연관된 이슈

* close #5 

## 작업 내용

<img width="953" alt="스크린샷 2025-01-01 오후 7 24 19" src="https://github.com/user-attachments/assets/865314bd-d039-4916-a307-19ef67f09509" />

최대 라인 수와 최소 라인 수를 3줄로 고정한다. 
최대 라인 수는 tailwind 기준 line-clamp-3를 사용하면 최대 3줄로 고정하고 나머지 부분은 "..."처리한다.
최소 라인 수는 line-height(1.25rem) * 3줄 = 3.75rem이고, heigh를 3.75rem로 고정하므로써 최소 라인 수를 3줄로 고정할 수 있다.

이미지와 같이 글이 넘칠 경우 3줄이 되고, 나머지 글을 "..."으로 처리된다.
글이 적을 경우에도 3줄로 고정된다.

## 참고

정리한 블로그 글입니다.
https://alstn113.tistory.com/28
