### PR TITLE
웹에서 시험 상세 내역을 인증 없이도 볼 수 있게 변경한다.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -102,6 +102,6 @@ tasks.register('copyDocument', Copy) {
     into file("src/main/resources/static/docs")
 }
 
-build {
+bootJar {
     dependsOn copyDocument
 }

--- a/web/src/components/exams/ExamSummaryCard.tsx
+++ b/web/src/components/exams/ExamSummaryCard.tsx
@@ -1,9 +1,7 @@
 import { ExamSummaryResponse } from '@/api/examAPI';
 import { Routes } from '@/constants';
-import useUser from '@/hooks/useUser';
 import { fromNowDate } from '@/lib/date.ts';
 import { Button, Card, CardFooter, CardHeader, Chip, Divider, Image } from '@nextui-org/react';
-import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router';
 import BaseCardBody from '../common/BaseCardBody';
 
@@ -12,14 +10,8 @@ interface ExamSummaryCardProps {
 }
 
 const ExamSummaryCard = ({ exam }: ExamSummaryCardProps) => {
-  const user = useUser();
   const navigate = useNavigate();
   const handleExamStart = () => {
-    if (!user) {
-      toast.error('로그인이 필요합니다.');
-      return;
-    }
-
     navigate(Routes.exam.intro(exam.id));
   };
 

--- a/web/src/pages/exams/ExamIntroPage.tsx
+++ b/web/src/pages/exams/ExamIntroPage.tsx
@@ -1,8 +1,10 @@
 import AsyncBoundary from '@/components/AsyncBoundary';
 import { Routes } from '@/constants';
 import useGetExam from '@/hooks/api/exam/useGetExam';
+import useUser from '@/hooks/useUser';
 import { fullDate } from '@/lib/date.ts';
 import { Button, Divider } from '@nextui-org/react';
+import toast from 'react-hot-toast';
 import { useNavigate, useParams } from 'react-router';
 
 const ExamIntroPage = () => {
@@ -21,10 +23,15 @@ const ExamIntroPage = () => {
 };
 
 const ExamProgressContent = ({ examId }: { examId: number }) => {
+  const user = useUser();
   const { data } = useGetExam(examId);
   const navigate = useNavigate();
 
   const handleExamStart = () => {
+    if (!user) {
+      toast.error('로그인이 필요합니다.');
+      return;
+    }
     navigate(Routes.exam.progress(examId));
   };
 


### PR DESCRIPTION
## 연관된 이슈

- close #14 

## 작업 내용

프론트엔드 intro 페이지 접근 시 인증 불필요하게 수정
