### PR TITLE
Hot-fix/v1.0.4 좋아요 로직 관련 문제 수정

### DIFF
--- a/server/src/main/java/com/fluffy/exam/infra/persistence/ExamRepositoryImpl.java
+++ b/server/src/main/java/com/fluffy/exam/infra/persistence/ExamRepositoryImpl.java
@@ -161,7 +161,7 @@ public class ExamRepositoryImpl implements ExamRepositoryCustom {
 
     @Override
     public Page<SubmittedExamSummaryDto> findSubmittedExamSummaries(Pageable pageable, Long memberId) {
-        JPAQuery<Long> countQuery = queryFactory.select(exam.count())
+        JPAQuery<Long> countQuery = queryFactory.select(exam.countDistinct())
                 .from(exam)
                 .join(submission).on(exam.id.eq(submission.examId))
                 .where(submission.memberId.eq(memberId));
@@ -184,7 +184,7 @@ public class ExamRepositoryImpl implements ExamRepositoryCustom {
                 .from(exam)
                 .leftJoin(member).on(exam.memberId.eq(member.id))
                 .join(submission).on(exam.id.eq(submission.examId))
-                .where(exam.id.in(examIds))
+                .where(exam.id.in(examIds).and(submission.memberId.eq(memberId)))
                 .groupBy(
                         exam.id,
                         exam.title,

--- a/web/src/api/examAPI.ts
+++ b/web/src/api/examAPI.ts
@@ -68,17 +68,14 @@ export const ExamAPI = {
     return data;
   },
 
-  like: async (examId: number, controller?: AbortController) => {
-    const { data } = await apiV1Client.post<void>(`/exams/${examId}/like`, {
-      signal: controller?.signal,
-    });
+  like: async (examId: number) => {
+    const { data } = await apiV1Client.post<void>(`/exams/${examId}/like`);
+
     return data;
   },
 
-  unlike: async (examId: number, controller?: AbortController) => {
-    const { data } = await apiV1Client.delete<void>(`/exams/${examId}/like`, {
-      signal: controller?.signal,
-    });
+  unlike: async (examId: number) => {
+    const { data } = await apiV1Client.delete<void>(`/exams/${examId}/like`);
     return data;
   },
 };

--- a/web/src/components/layouts/base/Footer.tsx
+++ b/web/src/components/layouts/base/Footer.tsx
@@ -15,23 +15,6 @@ const Footer = () => {
               @alstn113
             </a>
           </div>
-          <div>
-            service:
-            <a
-              href="https://github.com/alstn113/fluffy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-semibold hover:underline ml-1"
-            >
-              @fluffy
-            </a>
-          </div>
-          <div>
-            email:
-            <a href="mailto:alstn113@gmail.com" className="font-semibold hover:underline ml-1">
-              alstn113@gmail.com
-            </a>
-          </div>
         </div>
       </div>
     </div>

--- a/web/src/hooks/api/exam/useExamLikeManager.ts
+++ b/web/src/hooks/api/exam/useExamLikeManager.ts
@@ -97,6 +97,7 @@ const useExamLikeManager = ({
   const toggleLike = () => {
     if (!user) {
       toast.error('로그인이 필요합니다.');
+      return;
     }
 
     if (isLiked) {


### PR DESCRIPTION
## 연관된 이슈

- #33 
- #34 

## 작업 내용

- 비 로그인 시 좋아요 버튼 mutation 작동 막기
- 제출 한 시험 목록에서 제출 수가 다른 사람의 제출 수까지 포함되는 문제 수정
- useExamLikeManager의 공통 로직 분할

