### PR TITLE
서버에서 이미지 업로드 기능을 추가한다.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -71,6 +71,10 @@ dependencies {
     // monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    // aws
+    implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1')
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/server/src/main/java/com/fluffy/storage/application/StorageClient.java
+++ b/server/src/main/java/com/fluffy/storage/application/StorageClient.java
@@ -1,0 +1,10 @@
+package com.fluffy.storage.application;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageClient {
+
+    String upload(MultipartFile file);
+
+    void delete(String fileName);
+}

--- a/server/src/main/java/com/fluffy/storage/infra/AwsS3Client.java
+++ b/server/src/main/java/com/fluffy/storage/infra/AwsS3Client.java
@@ -1,0 +1,67 @@
+package com.fluffy.storage.infra;
+
+import com.fluffy.global.exception.BadRequestException;
+import com.fluffy.global.exception.NotFoundException;
+import com.fluffy.storage.application.StorageClient;
+import io.awspring.cloud.s3.S3Exception;
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class AwsS3Client implements StorageClient {
+
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Override
+    public String upload(MultipartFile file) {
+
+        if (file.isEmpty()) {
+            throw new BadRequestException("파일이 비어있습니다.");
+        }
+
+        String fileName = generateFileName(file.getOriginalFilename());
+
+        try (InputStream is = file.getInputStream()) {
+            S3Resource upload = s3Template.upload(bucketName, fileName, is);
+
+            return upload.getURL().toString();
+        } catch (IOException | S3Exception e) {
+            throw new BadRequestException("파일 업로드에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public void delete(String fileName) {
+        try {
+            s3Template.deleteObject(bucketName, fileName);
+        } catch (S3Exception e) {
+            throw new NotFoundException("파일을 찾을 수 없습니다.", e);
+        }
+    }
+
+    private String generateFileName(String originalFileName) {
+        if (originalFileName == null) {
+            throw new NotFoundException("파일 이름을 찾을 수 없습니다.");
+        }
+
+        int extensionIndex = originalFileName.lastIndexOf(".");
+
+        String extension = originalFileName.substring(extensionIndex);
+        String fileName = originalFileName.substring(0, extensionIndex);
+
+        String now = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss_SSS").format(System.currentTimeMillis());
+
+        return "%s-%s%s".formatted(fileName, now, extension);
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -27,6 +27,16 @@ spring:
     redis:
       host: localhost
       port: 6379
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      region:
+        static: ${AWS_S3_REGION}
+      s3:
+        bucket: ${AWS_S3_BUCKET}
+
 
 api-host: http://localhost:8080
 client-host: http://localhost:5173
@@ -93,6 +103,15 @@ spring:
     redis:
       host: redis
       port: 6379
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      region:
+        static: ${AWS_S3_REGION}
+      s3:
+        bucket: ${AWS_S3_BUCKET}
 
 api-host: https://api.fluffy.run
 client-host: https://www.fluffy.run

--- a/server/src/test/java/com/fluffy/support/AbstractIntegrationTest.java
+++ b/server/src/test/java/com/fluffy/support/AbstractIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.fluffy.support;
 
-import com.fluffy.storage.application.StorageClient;
 import com.fluffy.support.cleaner.DatabaseCleaner;
 import com.fluffy.support.cleaner.DatabaseClearExtension;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/server/src/test/java/com/fluffy/support/AbstractIntegrationTest.java
+++ b/server/src/test/java/com/fluffy/support/AbstractIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.fluffy.support;
 
+import com.fluffy.storage.application.StorageClient;
 import com.fluffy.support.cleaner.DatabaseCleaner;
 import com.fluffy.support.cleaner.DatabaseClearExtension;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -12,6 +12,16 @@ spring:
     redis:
       host: localhost
       port: 6379
+  cloud:
+    aws:
+      credentials:
+        access-key: access-key
+        secret-key: secret-key
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: bucket
+
 
 api-host: http://localhost:8080
 client-host: http://localhost:5173


### PR DESCRIPTION
## 연관된 이슈

- #40 
- close #41 

## 작업 내용

시험 지문을 에디터를 이용할 수 있도록 변경하는 작업이다.
드래그 앤 드랍 이미지 추가를 하기에 앞서 서버 이미지 업로드 기능을 작성한다.

supabase의 storage를 이용하려고 했으나 java spring은 지원하지 않는 관계로 aws s3를 사용한다.
io.awspring 의존성을 통해서 구현했다. s3Client 대신 추상화 수준이 더 높은 s3Template을 사용한다.