### PR TITLE
Elastic Cache - Valkey 도입

### DIFF
--- a/server/compose.local.yml
+++ b/server/compose.local.yml
@@ -1,7 +1,7 @@
 services:
   redis:
-    container_name: redis
-    image: redis:7.4.1
+    container_name: valkey
+    image: valkey/valkey:8.0
     restart: always
     ports:
       - '6379:6379'

--- a/server/compose.yml
+++ b/server/compose.yml
@@ -6,16 +6,8 @@ x-app: &app
     TZ: Asia/Seoul
     SPRING_PROFILES_ACTIVE: prod
   restart: always
-  depends_on:
-    - redis
 
 services:
-  redis:
-    container_name: redis
-    image: redis:7.4.1
-    restart: always
-    ports:
-      - '6379:6379'
   app-blue:
     <<: *app
     container_name: app-blue

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -2,10 +2,9 @@ spring:
   profiles:
     active: local
 ---
+spring.config.activate.on-profile: local
+
 spring:
-  config:
-    activate:
-      on-profile: local
   h2:
     console:
       path: /h2-console
@@ -82,10 +81,9 @@ management:
         include: health
 
 ---
+spring.config.activate.on-profile: prod
+
 spring:
-  config:
-    activate:
-      on-profile: prod
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -104,8 +102,8 @@ spring:
       ddl-auto: validate
   data:
     redis:
-      host: redis
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   cloud:
     aws:
       credentials:


### PR DESCRIPTION
## 연관된 이슈

- close #48 

## 작업 내용

기존에 Redis를 사용하기 EC2 내에서 Docker로 작동시켰다.
서버 이중화를 위해서 EC2에서 Redis를 분리하려고 한다.
AWS의 Elastic Cache와 Redis Cloud 중 Elastic Cache를 사용한다 - 프리티어 내에서 사용 가능
Redis OSS와 Valkey 중 더 저렴한 하고 성능이 좋은 Valkey를 사용하려고 한다.

Free Tier에서 제공하는 수준에서 사용하기 위해 다음과 같이 설정한다.
- 자체 설계 캐시
- 클러스터링 캐시
- 복제본 0개
- 백업 X

참고
- Redisson에서 Valkey를 지원한다. https://redisson.org/

