### PR TITLE
시험 상세 조회를 캐싱한다.

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.redisson:redisson-spring-boot-starter:3.33.0'
 
     // lombok

--- a/server/compose.local.yml
+++ b/server/compose.local.yml
@@ -1,7 +1,7 @@
 services:
   redis:
     container_name: valkey
-    image: valkey/valkey:8.0
+    image: valkey/valkey:8.0.1 # ElastiCache와 동일 버전 사용
     restart: always
     ports:
       - '6379:6379'

--- a/server/src/main/java/com/fluffy/exam/application/ExamQueryService.java
+++ b/server/src/main/java/com/fluffy/exam/application/ExamQueryService.java
@@ -18,6 +18,7 @@ import com.fluffy.reaction.domain.Like;
 import com.fluffy.reaction.domain.LikeQueryService;
 import com.fluffy.reaction.domain.LikeTarget;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -55,6 +56,7 @@ public class ExamQueryService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "examDetail", key = "#examId")
     public ExamDetailResponse getExamDetail(Long examId) {
         Exam exam = examRepository.findByIdOrThrow(examId);
 
@@ -62,6 +64,7 @@ public class ExamQueryService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "examWithAnswers", key = "#examId")
     public ExamWithAnswersResponse getExamWithAnswers(Long examId, Accessor accessor) {
         Exam exam = examRepository.findByIdOrThrow(examId);
 

--- a/server/src/main/java/com/fluffy/global/redis/config/RedisConfig.java
+++ b/server/src/main/java/com/fluffy/global/redis/config/RedisConfig.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -26,6 +27,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 @Configuration
 @RequiredArgsConstructor
+@Profile("!test")
 public class RedisConfig {
 
     private final RedisProperties properties;
@@ -72,7 +74,7 @@ public class RedisConfig {
         objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 직렬화를 위한 모듈 등록
         objectMapper.activateDefaultTyping(
                 BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
-                DefaultTyping.NON_FINAL,
+                DefaultTyping.EVERYTHING, // Deprecated 되었지만 나머지 값들은 예외 발생함.
                 JsonTypeInfo.As.PROPERTY
         );
 

--- a/server/src/main/java/com/fluffy/global/redis/config/RedisConfig.java
+++ b/server/src/main/java/com/fluffy/global/redis/config/RedisConfig.java
@@ -1,0 +1,81 @@
+package com.fluffy.global.redis.config;
+
+import static org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair.fromSerializer;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties properties;
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(fromSerializer(new GenericJackson2JsonRedisSerializer(createObjectMapper())))
+                .entryTtl((key, value) -> Duration.ofDays(3)); // 접근 시간 기준으로 3일 후 만료
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(lettuceConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer(createObjectMapper()));
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public LettuceConnectionFactory lettuceConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(properties.host());
+        configuration.setPort(properties.port());
+
+        LettuceClientConfigurationBuilder clientConfigBuilder = LettuceClientConfiguration.builder();
+        if (Boolean.TRUE.equals(properties.ssl().enabled())) {
+            clientConfigBuilder.useSsl();
+        }
+
+        return new LettuceConnectionFactory(configuration, clientConfigBuilder.build());
+    }
+
+    private ObjectMapper createObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 직렬화를 위한 모듈 등록
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder().allowIfBaseType(Object.class).build(),
+                DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        return objectMapper;
+    }
+}

--- a/server/src/main/java/com/fluffy/global/redis/config/RedisProperties.java
+++ b/server/src/main/java/com/fluffy/global/redis/config/RedisProperties.java
@@ -1,4 +1,4 @@
-package com.fluffy.global.redis;
+package com.fluffy.global.redis.config;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/server/src/main/java/com/fluffy/global/redis/config/RedissonConfig.java
+++ b/server/src/main/java/com/fluffy/global/redis/config/RedissonConfig.java
@@ -1,4 +1,4 @@
-package com.fluffy.global.redis;
+package com.fluffy.global.redis.config;
 
 import lombok.RequiredArgsConstructor;
 import org.redisson.Redisson;
@@ -9,7 +9,10 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
-public class RedisConfig {
+public class RedissonConfig {
+
+    private static final String REDIS_URL = "redis://%s:%d";
+    private static final String REDIS_SSL_URL = "rediss://%s:%d";
 
     private final RedisProperties properties;
 
@@ -25,8 +28,8 @@ public class RedisConfig {
 
     private String createUrl() {
         if (Boolean.TRUE.equals(properties.ssl().enabled())) {
-            return "rediss://%s:%d";
+            return REDIS_SSL_URL;
         }
-        return "redis://%s:%d";
+        return REDIS_URL;
     }
 }

--- a/server/src/main/java/com/fluffy/global/redis/distributedLock/AopForTransaction.java
+++ b/server/src/main/java/com/fluffy/global/redis/distributedLock/AopForTransaction.java
@@ -1,4 +1,4 @@
-package com.fluffy.global.redis;
+package com.fluffy.global.redis.distributedLock;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.springframework.stereotype.Component;

--- a/server/src/main/java/com/fluffy/global/redis/distributedLock/CustomSpringELParser.java
+++ b/server/src/main/java/com/fluffy/global/redis/distributedLock/CustomSpringELParser.java
@@ -1,4 +1,4 @@
-package com.fluffy.global.redis;
+package com.fluffy.global.redis.distributedLock;
 
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;

--- a/server/src/main/java/com/fluffy/global/redis/distributedLock/DistributedLock.java
+++ b/server/src/main/java/com/fluffy/global/redis/distributedLock/DistributedLock.java
@@ -1,4 +1,4 @@
-package com.fluffy.global.redis;
+package com.fluffy.global.redis.distributedLock;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/server/src/main/java/com/fluffy/global/redis/distributedLock/DistributedLockAspect.java
+++ b/server/src/main/java/com/fluffy/global/redis/distributedLock/DistributedLockAspect.java
@@ -1,4 +1,4 @@
-package com.fluffy.global.redis;
+package com.fluffy.global.redis.distributedLock;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/server/src/main/java/com/fluffy/submission/application/SubmissionLockService.java
+++ b/server/src/main/java/com/fluffy/submission/application/SubmissionLockService.java
@@ -3,7 +3,7 @@ package com.fluffy.submission.application;
 import com.fluffy.auth.domain.Member;
 import com.fluffy.exam.domain.Exam;
 import com.fluffy.global.exception.BadRequestException;
-import com.fluffy.global.redis.DistributedLock;
+import com.fluffy.global.redis.distributedLock.DistributedLock;
 import com.fluffy.submission.application.request.SubmissionAppRequest;
 import com.fluffy.submission.domain.Submission;
 import com.fluffy.submission.domain.SubmissionRepository;

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
       port: 6379
       ssl:
         enabled: false
+  cache:
+    type: redis
   cloud:
     aws:
       credentials:

--- a/server/src/test/java/com/fluffy/support/cleaner/DatabaseCleaner.java
+++ b/server/src/test/java/com/fluffy/support/cleaner/DatabaseCleaner.java
@@ -4,6 +4,8 @@ package com.fluffy.support.cleaner;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 public class DatabaseCleaner {
@@ -11,10 +13,14 @@ public class DatabaseCleaner {
     @PersistenceContext
     private EntityManager em;
 
+    @Autowired
+    private RedisTemplate<?, ?> redisTemplate;
+
     @Transactional
     public void clear() {
         em.clear();
         truncate();
+        clearCache();
     }
 
     private void truncate() {
@@ -31,5 +37,9 @@ public class DatabaseCleaner {
                 """;
 
         return em.createNativeQuery(sql).getResultList();
+    }
+
+    private void clearCache() {
+        redisTemplate.getConnectionFactory().getConnection().flushDb();
     }
 }

--- a/server/src/test/java/com/fluffy/support/cleaner/DatabaseCleaner.java
+++ b/server/src/test/java/com/fluffy/support/cleaner/DatabaseCleaner.java
@@ -4,8 +4,6 @@ package com.fluffy.support.cleaner;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 public class DatabaseCleaner {
@@ -13,14 +11,10 @@ public class DatabaseCleaner {
     @PersistenceContext
     private EntityManager em;
 
-    @Autowired
-    private RedisTemplate<?, ?> redisTemplate;
-
     @Transactional
     public void clear() {
         em.clear();
         truncate();
-        clearCache();
     }
 
     private void truncate() {
@@ -37,9 +31,5 @@ public class DatabaseCleaner {
                 """;
 
         return em.createNativeQuery(sql).getResultList();
-    }
-
-    private void clearCache() {
-        redisTemplate.getConnectionFactory().getConnection().flushDb();
     }
 }

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -12,6 +12,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  cache:
+    type: redis
   cloud:
     aws:
       credentials:

--- a/server/src/test/resources/application-test.yml
+++ b/server/src/test/resources/application-test.yml
@@ -12,6 +12,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+      ssl:
+        enabled: false
   cache:
     type: redis
   cloud:


### PR DESCRIPTION
## 연관된 이슈

- #53 

## 작업 내용

- 시험 상세 조회와 시험 상세와 답안 조회를 캐싱한다.
- 캐시 만료는 TTI로 3일을 지정했다. - 접근 시간 기준으로 3일 후 만료
- 직렬화/역직렬화 시 LocalDateTime 문제로 JavaTimeModule 추가
- objectMapper.activateDefaultTyping에서 DefaultTyping.EVERYTHING을 제외한 NON_FINAL등을 지정하면 예외가 발생하여 Deprecated된 EVERYTHING을 사용했다.

