### PR TITLE
Local과 Ubuntu에서 시간 정밀도 차이로 인한 LocalDateTime 테스트 실패 해결

### DIFF
--- a/server/src/main/kotlin/com/fluffy/exam/domain/Exam.kt
+++ b/server/src/main/kotlin/com/fluffy/exam/domain/Exam.kt
@@ -3,7 +3,6 @@ package com.fluffy.exam.domain
 import com.fluffy.global.exception.BadRequestException
 import com.fluffy.infra.persistence.AuditableEntity
 import jakarta.persistence.*
-import java.time.LocalDateTime
 
 @Entity
 class Exam(
@@ -73,7 +72,7 @@ class Exam(
         questions.forEach { it.updateExam(this) }
         this._questions.addAll(questions)
 
-        this.updatedAt = LocalDateTime.now()
+        updateTimestamp()
     }
 
     fun publish() {

--- a/server/src/main/kotlin/com/fluffy/infra/persistence/AuditableEntity.kt
+++ b/server/src/main/kotlin/com/fluffy/infra/persistence/AuditableEntity.kt
@@ -12,12 +12,12 @@ import java.time.temporal.ChronoUnit
 abstract class AuditableEntity {
 
     @CreatedDate
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false, columnDefinition = "TIMESTAMP(6)")
     var createdAt: LocalDateTime = LocalDateTime.MIN
         protected set
 
     @LastModifiedDate
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TIMESTAMP(6)")
     var updatedAt: LocalDateTime = LocalDateTime.MIN
         protected set
 

--- a/server/src/main/kotlin/com/fluffy/infra/persistence/AuditableEntity.kt
+++ b/server/src/main/kotlin/com/fluffy/infra/persistence/AuditableEntity.kt
@@ -1,12 +1,11 @@
 package com.fluffy.infra.persistence
 
-import jakarta.persistence.Column
-import jakarta.persistence.EntityListeners
-import jakarta.persistence.MappedSuperclass
+import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener::class)
@@ -21,4 +20,23 @@ abstract class AuditableEntity {
     @Column(nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.MIN
         protected set
+
+    @PrePersist
+    fun prePersist() {
+        createdAt = truncateToMicros(createdAt)
+        updatedAt = truncateToMicros(updatedAt)
+    }
+
+    @PreUpdate
+    fun preUpdate() {
+        updatedAt = truncateToMicros(updatedAt)
+    }
+
+    fun updateTimestamp() {
+        updatedAt = truncateToMicros(LocalDateTime.now())
+    }
+
+    private fun truncateToMicros(dateTime: LocalDateTime): LocalDateTime {
+        return dateTime.truncatedTo(ChronoUnit.MICROS)
+    }
 }

--- a/server/src/test/kotlin/com/fluffy/comment/application/ExamCommentQueryServiceTest.kt
+++ b/server/src/test/kotlin/com/fluffy/comment/application/ExamCommentQueryServiceTest.kt
@@ -58,7 +58,7 @@ class ExamCommentQueryServiceTest : BehaviorSpec({
                 )
                 every { examCommentRepository.findRootComments(any()) } returns deletedRootComments
 
-                val response  = examCommentQueryService.getRootComments(examId)
+                val response = examCommentQueryService.getRootComments(examId)
                 val expected = listOf(
                     ExamRootCommentDtoFixture.create(id = 1L, isDeleted = true).asDeleted(),
                     ExamRootCommentDtoFixture.create(id = 2L, isDeleted = false)

--- a/server/src/test/kotlin/com/fluffy/exam/application/ExamQueryServiceIT.kt
+++ b/server/src/test/kotlin/com/fluffy/exam/application/ExamQueryServiceIT.kt
@@ -237,11 +237,11 @@ class ExamQueryServiceIT(
 
         response.content[0].examId shouldBe exam1.id
         response.content[0].submissionCount shouldBe 2
-//        response.content[0].lastSubmissionDate shouldBe submission3.createdAt
+        response.content[0].lastSubmissionDate shouldBe submission3.createdAt
 
         response.content[1].examId shouldBe exam2.id
         response.content[1].submissionCount shouldBe 1
-//        response.content[1].lastSubmissionDate shouldBe submission2.createdAt
+        response.content[1].lastSubmissionDate shouldBe submission2.createdAt
 
         response.pageInfo.currentPage shouldBe 0
         response.pageInfo.totalPages shouldBe 1

--- a/server/src/test/kotlin/com/fluffy/exam/domain/ExamRepositoryIT.kt
+++ b/server/src/test/kotlin/com/fluffy/exam/domain/ExamRepositoryIT.kt
@@ -144,8 +144,8 @@ class ExamRepositoryIT(
         summaries.size shouldBe 2
         summaries.content.map(SubmittedExamSummaryDto::examId) shouldBe listOf(publishedExam2.id, publishedExam1.id)
         summaries.content.map(SubmittedExamSummaryDto::submissionCount) shouldBe listOf(1L, 2L)
-//        summaries.content.map(SubmittedExamSummaryDto::lastSubmissionDate) shouldBe
-//                listOf(exam2Submission2.createdAt, exam1Submission2.createdAt)
+        summaries.content.map(SubmittedExamSummaryDto::lastSubmissionDate) shouldBe
+                listOf(exam2Submission2.createdAt, exam1Submission2.createdAt)
     }
 
     private fun createExam(memberId: Long, published: Boolean = true, questionCount: Int = 1): Exam {

--- a/server/src/test/kotlin/com/fluffy/submission/application/SubmissionQueryServiceIT.kt
+++ b/server/src/test/kotlin/com/fluffy/submission/application/SubmissionQueryServiceIT.kt
@@ -40,11 +40,11 @@ class SubmissionQueryServiceIT(
         // then
         response[0].id shouldBe submission2.id
         response[0].participant.id shouldBe member2.id
-//        response[0].submittedAt shouldBe submission1.createdAt
+        response[0].submittedAt shouldBe submission2.createdAt
 
         response[1].id shouldBe submission1.id
         response[1].participant.id shouldBe member1.id
-//        response[1].submittedAt shouldBe submission2.createdAt
+        response[1].submittedAt shouldBe submission1.createdAt
     }
 
     @Test
@@ -66,7 +66,7 @@ class SubmissionQueryServiceIT(
         response.answers.size shouldBe 1
         response.answers[0].id shouldBe submission.id
         response.participant.id shouldBe member.id
-//        response.submittedAt shouldBe submission.createdAt
+        response.submittedAt shouldBe submission.createdAt
     }
 
     @Test
@@ -91,10 +91,10 @@ class SubmissionQueryServiceIT(
 
         // then
         response[0].submissionId shouldBe submission4.id
-//        response[0].submittedAt shouldBe submission4.createdAt
+        response[0].submittedAt shouldBe submission4.createdAt
 
         response[1].submissionId shouldBe submission1.id
-//        response[1].submittedAt shouldBe submission1.createdAt
+        response[1].submittedAt shouldBe submission1.createdAt
     }
 
     private fun createExam(memberId: Long): Exam {

--- a/server/src/test/kotlin/com/fluffy/submission/domain/SubmissionRepositoryIT.kt
+++ b/server/src/test/kotlin/com/fluffy/submission/domain/SubmissionRepositoryIT.kt
@@ -66,8 +66,8 @@ class SubmissionRepositoryIT(
         summaries.size shouldBe 3
         summaries.map { it.participant.id } shouldContainExactly listOf(member2.id, member2.id, member1.id)
         summaries.map { it.id }.size shouldBe 3
-//        summaries.map { it.submittedAt } shouldContainExactly
-//                listOf(submission4.createdAt, submission2.createdAt, submission1.createdAt)
+        summaries.map { it.submittedAt } shouldContainExactly
+                listOf(submission4.createdAt, submission2.createdAt, submission1.createdAt)
     }
 
     @Test
@@ -91,8 +91,8 @@ class SubmissionRepositoryIT(
         // then
         summaries.size shouldBe 2
         summaries.map { it.submissionId } shouldContainExactly listOf(submission4.id, submission1.id)
-//        summaries.map { it.submittedAt } shouldContainExactly
-//                listOf(submission4.createdAt, submission1.createdAt)
+        summaries.map { it.submittedAt } shouldContainExactly
+                listOf(submission4.createdAt, submission1.createdAt)
     }
 
     private fun createExam(memberId: Long): Exam {


### PR DESCRIPTION
## 연관된 이슈

* close #74 

## 작업 내용

### 블로그 글 작성

- https://alstn113.tistory.com/48

### 문제

간략히해서 아래와 같은 테스트가 실패했다.

```kotlin
fun '생성 시간 비교 테스트'() {
    val savedSubmission = submissionRepository.save(Submission())
    val foundSubmission = submissionRepository.findByIdOrThrow(submission.id)

    println(savedSubmission.createdAt)
    println(foundSubmission.createdAt)
    
    savedSubmission.createdAt shouldBe foundSubmission.createdAt
}
```

### 문제 인식

- 로컬 환경에서 정상적으로 통과되던 테스트가 CI(Github Actions, Ubuntu) 환경에서 실패했다.
- 개발 환경은 PostgreSQL, Testcontainers를 사용하고 있었다.
- 로컬 환경(MacOS)에서는 LocalDateTime의 시간 정밀도가 마이크로초(6자리)지만, CI 환경(Ubuntu)의 시간 정밀도는 나노초(9자리)였다.

### 문제 해결

- 응답된 값에서 마이크로초로 절삭해서 비교하려는 시도를 했지만, PostgreSQL의 경우 나노초를 반올림해서 마이크로초로 만들기 때문에 테스트가 확률적으로 실패할 수 있었다. (해결 X)
- @CreatedDate로 영속화 전에 부여되던 LocalDateTime.now()의 값을 마이크로초로 절삭해서 createdAt에 부여했다. 이 경우, entity.createdAt의 값과 데이터베이스의 createdAt의 값이 같기 때문에 값 불일치 문제가 일어나지 않았다.