### PR TITLE
코틀린으로 마이그레이션 이후 캐시 역직렬화 문제 발생으로 캐시 코드 주석 처리

### DIFF
--- a/server/src/main/kotlin/com/fluffy/exam/application/ExamQueryService.kt
+++ b/server/src/main/kotlin/com/fluffy/exam/application/ExamQueryService.kt
@@ -17,7 +17,6 @@ import com.fluffy.global.web.Accessor
 import com.fluffy.reaction.domain.Like
 import com.fluffy.reaction.domain.LikeQueryService
 import com.fluffy.reaction.domain.LikeTarget
-import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -52,7 +51,7 @@ class ExamQueryService(
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = ["examDetail"], key = "#examId")
+//    @Cacheable(value = ["examDetail"], key = "#examId")
     fun getExamDetail(examId: Long): ExamDetailResponse {
         val exam = examRepository.findByIdOrThrow(examId)
 


### PR DESCRIPTION
## 연관된 이슈

* close #77 

## 작업 내용

코틀린으로 마이그레이션 이후 캐시 역직렬화 문제 발생으로 캐시 코드 주석 처리

## 예상되는 원인

- ObjectMapper 빈 생성자 문제
- List<>  직렬화 시 [ { [ 값 ] } ] 되는 문제